### PR TITLE
Support for Laravel 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 # aliased to a recent 5.6.x version
   - 5.6
   # aliased to a recent 7.x version
-  - 7.1
   - 7.2
   - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to a recent 5.5.x version
-  - 5.5
-  # aliased to a recent 5.6.x version
+# aliased to a recent 5.6.x version
   - 5.6
   # aliased to a recent 7.x version
+  - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ php:
   - 5.6
   # aliased to a recent 7.x version
   - 7.2
-  # aliased to a recent hhvm version
-  - hhvm
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   # aliased to a recent 5.6.x version
   - 5.6
   # aliased to a recent 7.x version
-  - 7.0
+  - 7.2
   # aliased to a recent hhvm version
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A thin wrapper around Illuminate/Collection that allows for enforcing type constraints on the collection elements",
     "license": "MIT",
     "require": {
-        "illuminate/support": "4.0.0 - 5",
+        "illuminate/support": "^4.0 | ^5.0 | ^6.0",
         "php": ">=5.5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allow package to be used on Laravel 6.0.

- Removed HHVM since it's not supported anymore. 
- Check php 7.2/7.3 instead of 7.0
- Removed php 5.5 check.